### PR TITLE
Minimap Shape Support and Distance Filtering

### DIFF
--- a/Settings.lua
+++ b/Settings.lua
@@ -58,6 +58,7 @@ local function buildOptions()
                     hideStale = { type = "toggle", name = "Hide Stale", order = 3, get = function() return L.db.profile.mapFilters.hideStale end, set = function(_, val) L.db.profile.mapFilters.hideStale = val; refreshUI() end, },
                     hideLooted = { type = "toggle", name = "Hide Looted", desc = "Hide discoveries already looted by this character.", order = 4, get = function() return L.db.profile.mapFilters.hideLooted end, set = function(_, val) L.db.profile.mapFilters.hideLooted = val; refreshUI() end, },
                     pinSizeSlider = { type = "range", name = "Map Icon Size", desc = "Adjust the size of the discovery icons on the world map.", order = 5, min = 8, max = 32, step = 1, get = function() return L.db.profile.mapFilters.pinSize end, set = function(_, val) L.db.profile.mapFilters.pinSize = val; refreshUI() end, },
+                    maxMinimapDistance = { type = "range", name = "Max Minimap Distance", desc = "Maximum distance from player to show minimap icons. 0 = unlimited. Distance is in yards (approximate, varies by zone).", order = 6, min = 0, max = 2000, step = 50, get = function() local val = L.db.profile.mapFilters.maxMinimapDistance or 0; return val * 3340 end, set = function(_, val) L.db.profile.mapFilters.maxMinimapDistance = val / 3340; refreshUI() end, },
                 },
             },
             behavior = {


### PR DESCRIPTION
- Adds dynamic minimap shape detection (addons like SexyMap can change minimap shape) to display markers along the edges correctly.
- Configurable distance filtering for minimap icons, to hide far away markers. (0-2000 yards, 0 = unlimited). On first glance it seems accurate to the TomTom distance, but might vary by zone.

<img width="1046" height="436" alt="{AC77D641-56EA-4C23-A1BA-CC5BAEFF20EA}" src="https://github.com/user-attachments/assets/283c7569-cf70-4b07-accb-8e8ce6a3c55a" />
