### PR TITLE
fix: Tooltip strata fix for ProximityList panel

### DIFF
--- a/Modules/ProximityList.lua
+++ b/Modules/ProximityList.lua
@@ -139,7 +139,6 @@ function ProximityList:CreateFrame()
                 else
                     tooltip:SetParent(UIParent)
                 end
-                tooltip:SetFrameStrata("TOOLTIP")
                 
                 tooltip:SetOwner(self, "ANCHOR_RIGHT")
                 
@@ -150,6 +149,7 @@ function ProximityList:CreateFrame()
                 end
                 
                 tooltip:Show()
+                tooltip:SetFrameStrata("TOOLTIP") -- Must be called AFTER Show() to properly force above other frames
             end
 
             


### PR DESCRIPTION
## Problem

Tooltips in the ProximityList (Nearby Discoveries panel) were displaying beneath certain windows/frames when hovering over discovery items.

## Root Cause

In `Modules/ProximityList.lua` (lines 133-152), `SetFrameStrata("TOOLTIP")` was being called **before** `tooltip:Show()`. WoW's GameTooltip may reset its strata during the `SetOwner`/`Show` process, causing the strata to not be properly applied.

## Solution

Moved `tooltip:SetFrameStrata("TOOLTIP")` to **after** `tooltip:Show()` to match the pattern used successfully in all other modules.

### Diff

```diff
@@ -139,7 +139,6 @@ btn:SetScript("OnEnter", function(self)
                 else
                     tooltip:SetParent(UIParent)
                 end
-                tooltip:SetFrameStrata("TOOLTIP")
                 
                 tooltip:SetOwner(self, "ANCHOR_RIGHT")
                 
@@ -149,6 +149,7 @@ btn:SetScript("OnEnter", function(self)
                 end
                 
                 tooltip:Show()
+                tooltip:SetFrameStrata("TOOLTIP") -- Must be called AFTER Show()
             end
```

## Why This Pattern Works

The correct pattern is:
```lua
GameTooltip:SetOwner(self, "ANCHOR_XXX")
GameTooltip:SetHyperlink(link)
GameTooltip:Show()
GameTooltip:SetFrameStrata("TOOLTIP") -- AFTER Show()
```

This ensures the strata is set after WoW finishes initializing the tooltip's display properties.

## Testing

1. Open World Map with discoveries displayed
2. Hover over a cluster of pins to trigger ProximityList panel
3. Hover over items in the ProximityList - tooltips should appear **above** the panel
4. Verify tooltips also appear above other addon frames (bags, TSM, etc.)