### PR TITLE
Fix Viewer crash when using Mystic Scroll Vendor filter

### DIFF
--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -93,6 +93,7 @@ Viewer.totalItems     = 0
 Viewer.columnFilters  = {
     eq       = { slot = {}, type = {}, class = {} },
     ms       = { class = {} },
+    msv      = { slot = {}, type = {}, class = {} },
     zone     = {},
     source   = {},
     quality  = {},


### PR DESCRIPTION
Initialize msv table in Viewer.columnFilters to prevent nil index error.