### PR TITLE
Add Filter Collected Mystic Enchants, Collected Transmogs for WF items and Disable Fade Effect option

### DIFF
--- a/LootCollector.lua
+++ b/LootCollector.lua
@@ -123,7 +123,9 @@ local dbDefaults = {
             hideUncached = false,
             hideUnconfirmed = false,
             hideLearnedTransmog = false,
+            hideCollectedME = false,
 		    hidePlayerNames = false,
+            disableFadeEffect = false,
             pinSize = 17, 
             minimapPinSize = 14, 
             showZoneSummaries = false,
@@ -432,6 +434,7 @@ function LootCollector:GetFilters()
     if f.hideUnconfirmed == nil then f.hideUnconfirmed = false end
     if f.hideUncached == nil then f.hideUncached = false end
     if f.hideLearnedTransmog == nil then f.hideLearnedTransmog = false end
+    if f.hideCollectedME == nil then f.hideCollectedME = false end
     if f.minRarity == nil then f.minRarity = 0 end
     if f.allowedEquipLoc == nil then f.allowedEquipLoc = {} end
     if f.usableByClasses == nil then f.usableByClasses = {} end
@@ -440,6 +443,7 @@ function LootCollector:GetFilters()
     if f.showWorldforged == nil then f.showWorldforged = true end
     if f.maxMinimapDistance == nil then f.maxMinimapDistance = 1400 end
     if f.pinSize == nil then f.pinSize = 16 end
+    if f.disableFadeEffect == nil then f.disableFadeEffect = false end
     return f
 end
 
@@ -459,6 +463,60 @@ end
 local appearanceCache = {}
 local appearanceCacheTime = {}
 local APPEARANCE_CACHE_DURATION = 300
+
+local meCollectedCache = {}
+local meCollectedCacheTime = {}
+local ME_COLLECTED_CACHE_DURATION = 300
+
+function LootCollector:IsMysticEnchantCollected(itemID)
+    if not itemID or itemID == 0 then return false end
+
+    local now = GetTime()
+    if meCollectedCacheTime[itemID] and (now - meCollectedCacheTime[itemID]) < ME_COLLECTED_CACHE_DURATION then
+        return meCollectedCache[itemID]
+    end
+
+    local isCollected = false
+
+    -- Try direct API first (Ascension-specific)
+    if C_MysticEnchant and C_MysticEnchant.IsCollected then
+        local ok, result = pcall(C_MysticEnchant.IsCollected, itemID)
+        if ok and result then
+            isCollected = true
+        end
+    end
+
+    -- Fallback: scan the item tooltip for "Collected" text
+    if not isCollected then
+        local scannerName = "LootCollectorMEScannerTooltip"
+        local scanner = _G[scannerName]
+        if not scanner then
+            scanner = CreateFrame("GameTooltip", scannerName, UIParent, "GameTooltipTemplate")
+            scanner:SetOwner(UIParent, "ANCHOR_NONE")
+        end
+        scanner:ClearLines()
+        scanner:SetOwner(UIParent, "ANCHOR_NONE")
+        scanner:SetHyperlink("item:" .. itemID)
+
+        for i = 1, scanner:NumLines() do
+            local leftText = _G[scannerName .. "TextLeft" .. i]
+            if leftText then
+                local text = leftText:GetText()
+                local stripped = text and text:gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "") or ""
+                if stripped == "Collected" then
+                    isCollected = true
+                    break
+                end
+            end
+        end
+        scanner:Hide()
+    end
+
+    meCollectedCache[itemID] = isCollected
+    meCollectedCacheTime[itemID] = now
+
+    return isCollected
+end
 
 function LootCollector:IsAppearanceCollected(itemID)
     if not itemID or itemID == 0 then return false end
@@ -495,6 +553,10 @@ function LootCollector:DiscoveryPassesFilters(d)
     end
 
     if f.hideLearnedTransmog and d.i and d.i > 0 and self:IsAppearanceCollected(d.i) then
+        return false
+    end
+
+    if f.hideCollectedME and Constants and d.dt == Constants.DISCOVERY_TYPE.MYSTIC_SCROLL and d.i and d.i > 0 and self:IsMysticEnchantCollected(d.i) then
         return false
     end
 
@@ -1229,4 +1291,146 @@ SlashCmdList["LCCLEANUP"] = function()
     else
         print("|cffff7f00LootCollector:|r Core module not available.")
     end
+end
+
+-- Diagnostic command: /lcme [itemID]
+-- Dumps C_MysticEnchant API and tests ME collection detection for a given item
+SLASH_LCMEDIAG1 = "/lcme"
+SlashCmdList["LCMEDIAG"] = function(msg)
+    local prefix = "|cff00ff00[LC-ME-Diag]|r "
+
+    -- 1. Dump all C_MysticEnchant methods
+    print(prefix .. "--- C_MysticEnchant API dump ---")
+    if C_MysticEnchant then
+        local count = 0
+        for k, v in pairs(C_MysticEnchant) do
+            print(prefix .. "  " .. tostring(k) .. " = " .. type(v))
+            count = count + 1
+        end
+        if count == 0 then
+            print(prefix .. "  (table exists but is empty)")
+        end
+    else
+        print(prefix .. "  C_MysticEnchant does NOT exist")
+    end
+
+    -- 2. Dump C_MysticEnchant sub-tables (sometimes APIs are nested)
+    print(prefix .. "--- Checking related globals ---")
+    for _, name in ipairs({"C_MysticEnchantCollection", "C_Enchant", "C_MysticScroll", "C_Collection"}) do
+        if _G[name] then
+            print(prefix .. "  " .. name .. " EXISTS:")
+            for k, v in pairs(_G[name]) do
+                print(prefix .. "    " .. tostring(k) .. " = " .. type(v))
+            end
+        end
+    end
+
+    -- 3. Test with a specific item ID
+    local testID = tonumber(msg) or 200118 -- default: Air Ascendance from screenshot
+    print(prefix .. "--- Testing itemID: " .. testID .. " ---")
+
+    -- 3a. GetItemInfo
+    local itemName, itemLink, _, _, _, _, _, _, _, itemTexture = GetItemInfo(testID)
+    print(prefix .. "  GetItemInfo name: " .. tostring(itemName))
+    print(prefix .. "  GetItemInfo link: " .. tostring(itemLink))
+
+    -- 3b. GetItemSpell (what spell does this item teach?)
+    if GetItemSpell then
+        local spellName, spellID = GetItemSpell(testID)
+        print(prefix .. "  GetItemSpell: name=" .. tostring(spellName) .. " id=" .. tostring(spellID))
+
+        if spellID then
+            -- Check if spell is known
+            if IsSpellKnown then
+                print(prefix .. "  IsSpellKnown(" .. spellID .. "): " .. tostring(IsSpellKnown(spellID)))
+            end
+            if IsPlayerSpell then
+                print(prefix .. "  IsPlayerSpell(" .. spellID .. "): " .. tostring(IsPlayerSpell(spellID)))
+            end
+        end
+    end
+
+    -- 3c. Scanner tooltip dump
+    local scannerName = "LootCollectorMEScannerTooltip"
+    local scanner = _G[scannerName]
+    if not scanner then
+        scanner = CreateFrame("GameTooltip", scannerName, UIParent, "GameTooltipTemplate")
+    end
+    scanner:SetOwner(UIParent, "ANCHOR_NONE")
+    scanner:ClearLines()
+    scanner:SetHyperlink("item:" .. testID)
+
+    print(prefix .. "  Scanner tooltip lines (" .. scanner:NumLines() .. "):")
+    for i = 1, scanner:NumLines() do
+        local leftFS = _G[scannerName .. "TextLeft" .. i]
+        local rightFS = _G[scannerName .. "TextRight" .. i]
+        local leftText = leftFS and leftFS:GetText() or ""
+        local rightText = rightFS and rightFS:GetText() or ""
+        local r, g, b = 1, 1, 1
+        if leftFS and leftFS.GetTextColor then
+            r, g, b = leftFS:GetTextColor()
+        end
+        print(prefix .. string.format("    L%d: [%.1f,%.1f,%.1f] %s | %s", i, r, g, b, leftText, rightText))
+        -- Byte dump for lines containing "Collect"
+        if leftText and leftText:find("Collect") then
+            local bytes = {}
+            for j = 1, #leftText do
+                bytes[#bytes+1] = string.format("%02X", string.byte(leftText, j))
+            end
+            print(prefix .. "    ^ BYTES: " .. table.concat(bytes, " "))
+            print(prefix .. "    ^ LEN: " .. #leftText .. " == 'Collected': " .. tostring(leftText == "Collected"))
+        end
+    end
+    scanner:Hide()
+
+    -- 4. Direct test of IsMysticEnchantCollected
+    print(prefix .. "--- Direct IsMysticEnchantCollected test ---")
+    -- Clear cache first to force re-scan
+    meCollectedCache[testID] = nil
+    meCollectedCacheTime[testID] = nil
+    local result = LootCollector:IsMysticEnchantCollected(testID)
+    print(prefix .. "  IsMysticEnchantCollected(" .. testID .. ") = " .. tostring(result))
+
+    -- 5. Check the filter setting
+    print(prefix .. "--- Filter setting check ---")
+    local filters = LootCollector:GetFilters()
+    print(prefix .. "  hideCollectedME = " .. tostring(filters.hideCollectedME))
+
+    -- 6. Check GetEnchantInfoByItem
+    print(prefix .. "--- C_MysticEnchant.GetEnchantInfoByItem test ---")
+    if C_MysticEnchant and C_MysticEnchant.GetEnchantInfoByItem then
+        local ok, r1, r2, r3, r4, r5 = pcall(C_MysticEnchant.GetEnchantInfoByItem, testID)
+        if ok then
+            print(prefix .. "  Returns: " .. tostring(r1) .. ", " .. tostring(r2) .. ", " .. tostring(r3) .. ", " .. tostring(r4) .. ", " .. tostring(r5))
+        else
+            print(prefix .. "  ERROR: " .. tostring(r1))
+        end
+    end
+
+    -- 7. Check GetMysticScrolls (list of collected scrolls?)
+    print(prefix .. "--- C_MysticEnchant.GetMysticScrolls test ---")
+    if C_MysticEnchant and C_MysticEnchant.GetMysticScrolls then
+        local ok, scrolls = pcall(C_MysticEnchant.GetMysticScrolls)
+        if ok and scrolls then
+            print(prefix .. "  Type: " .. type(scrolls))
+            if type(scrolls) == "table" then
+                local count = 0
+                for k, v in pairs(scrolls) do
+                    if count < 5 then
+                        print(prefix .. "    [" .. tostring(k) .. "] = " .. tostring(v))
+                    end
+                    count = count + 1
+                end
+                print(prefix .. "  Total entries: " .. count)
+            else
+                print(prefix .. "  Value: " .. tostring(scrolls))
+            end
+        elseif ok then
+            print(prefix .. "  Returned nil")
+        else
+            print(prefix .. "  ERROR: " .. tostring(scrolls))
+        end
+    end
+
+    print(prefix .. "--- End diagnostic ---")
 end

--- a/Modules/Map.lua
+++ b/Modules/Map.lua
@@ -912,6 +912,8 @@ local function GetQualityColor(quality)
 end
 
 local function AlphaForStatus(status)
+  local f = L:GetFilters()
+  if f.disableFadeEffect then return 1.0 end
   if status == "FADING" then return 0.65 elseif status == "STALE" then return 0.45 end
   return 1.0
 end
@@ -1412,6 +1414,9 @@ local function BuildFilterEasyMenu()
   addToggle("Hide Faded", "hideFaded", hideSub)
   addToggle("Hide Stale", "hideStale", hideSub)
   addToggle("Hide Collected Appearances", "hideLearnedTransmog", hideSub)
+  addToggle("Hide Collected Mystic Enchants", "hideCollectedME", hideSub)
+  table.insert(hideSub, { text = "", notCheckable = true, disabled = true })
+  addToggle("Disable Fade Effect", "disableFadeEffect", hideSub)
   table.insert(menu, { text = "Hide", hasArrow = true, notCheckable = true, menuList = hideSub })
   
   local showSub = { { text = "Show Item Types", isTitle = true, notCheckable = true } }

--- a/Modules/Settings.lua
+++ b/Modules/Settings.lua
@@ -229,6 +229,28 @@ local function buildOptions()
 							refreshUI()
 						end,
 					},
+					hideCollectedME = {
+						type = "toggle",
+						name = "Hide Collected Mystic Enchants",
+						order = 4.2,
+						desc = "Hide Mystic Scroll discoveries for enchants you have already collected.",
+						get = function() return L.db.profile.mapFilters.hideCollectedME end,
+						set = function(_, v)
+							L.db.profile.mapFilters.hideCollectedME = v
+							refreshUI()
+						end,
+					},
+					disableFadeEffect = {
+						type = "toggle",
+						name = "Disable Fade Effect",
+						order = 4.3,
+						desc = "Show all map pins at full opacity, even if their discovery is fading or stale.",
+						get = function() return L.db.profile.mapFilters.disableFadeEffect end,
+						set = function(_, v)
+							L.db.profile.mapFilters.disableFadeEffect = v
+							refreshUI()
+						end,
+					},
 					hidePlayerNames = {
 						type = "toggle",
 						name = "Hide Player Names",

--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -43,6 +43,7 @@ local CLASS_OPTIONS = {
 }
 
 Viewer.lootedFilterState = nil 
+Viewer.collectedMEFilterState = nil 
 
 local time = time or os.time
 
@@ -834,6 +835,20 @@ GetFilteredDatasetForUniqueValues = function(context)
             local isLooted = Viewer:IsLootedByChar(data.guid)
             if Viewer.lootedFilterState == true and not isLooted then return false end
             if Viewer.lootedFilterState == false and isLooted then return false end
+        end
+
+        -- Collected ME filter
+        if Viewer.collectedMEFilterState ~= nil then
+            local Constants = L:GetModule("Constants", true)
+            local isME = Constants and data.discovery.dt == Constants.DISCOVERY_TYPE.MYSTIC_SCROLL
+            if isME and data.discovery.i and data.discovery.i > 0 then
+                local isCollectedME = L:IsMysticEnchantCollected(data.discovery.i)
+                if Viewer.collectedMEFilterState == true and not isCollectedME then return false end
+                if Viewer.collectedMEFilterState == false and isCollectedME then return false end
+            elseif not isME then
+                -- Non-ME items: hide when filtering for collected MEs only
+                if Viewer.collectedMEFilterState == true then return false end
+            end
         end
 
         
@@ -2049,6 +2064,19 @@ function Viewer:GetFilteredDiscoveries()
             if Viewer.lootedFilterState == false and isLooted then return false end
         end
 
+        -- Collected ME filter
+        if Viewer.collectedMEFilterState ~= nil then
+            local Constants = L:GetModule("Constants", true)
+            local isME = Constants and data.discovery.dt == Constants.DISCOVERY_TYPE.MYSTIC_SCROLL
+            if isME and data.discovery.i and data.discovery.i > 0 then
+                local isCollectedME = L:IsMysticEnchantCollected(data.discovery.i)
+                if Viewer.collectedMEFilterState == true and not isCollectedME then return false end
+                if Viewer.collectedMEFilterState == false and isCollectedME then return false end
+            elseif not isME then
+                if Viewer.collectedMEFilterState == true then return false end
+            end
+        end
+
         
         if not filterPredicates.columnFilters.duplicates(data) then return false end
 
@@ -2132,6 +2160,9 @@ function Viewer:GetFilterStateHash()
     
     if self.lootedFilterState ~= nil then
         _tinsert(filterEntries, "looted:" .. tostring(self.lootedFilterState))
+    end
+    if self.collectedMEFilterState ~= nil then
+        _tinsert(filterEntries, "collectedME:" .. tostring(self.collectedMEFilterState))
     end
 
     
@@ -2218,6 +2249,10 @@ function Viewer:HasActiveFilters()
 
     
     if self.lootedFilterState ~= nil or size(self.columnFilters.looted) > 0 then
+        return true
+    end
+
+    if self.collectedMEFilterState ~= nil then
         return true
     end
 
@@ -2328,6 +2363,20 @@ function Viewer:UpdateFilterButtonStates()
         else
             setButtonTextColor(self.duplicatesFilterBtn, 1, 1, 1) 
             self.duplicatesFilterBtn:SetText("Duplicates")
+        end
+    end
+
+    -- Collected ME filter button state
+    if self.collectedMEFilterBtn then
+        if self.collectedMEFilterState == true then
+            setButtonTextColor(self.collectedMEFilterBtn, 1, 0.8, 0.2)
+            self.collectedMEFilterBtn:SetText("Collected: Yes")
+        elseif self.collectedMEFilterState == false then
+            setButtonTextColor(self.collectedMEFilterBtn, 1, 0.8, 0.2)
+            self.collectedMEFilterBtn:SetText("Collected: No")
+        else
+            setButtonTextColor(self.collectedMEFilterBtn, 1, 1, 1)
+            self.collectedMEFilterBtn:SetText("Collected: All")
         end
     end
 end
@@ -2925,8 +2974,8 @@ function Viewer:CreateWindow()
 
     
     local sourceFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    sourceFilterBtn:SetSize(70, BUTTON_HEIGHT)
-    sourceFilterBtn:SetPoint("LEFT", filtersLabel, "RIGHT", 10, 0)
+    sourceFilterBtn:SetSize(55, BUTTON_HEIGHT)
+    sourceFilterBtn:SetPoint("LEFT", filtersLabel, "RIGHT", 5, 0)
     sourceFilterBtn:SetText("Source")
     sourceFilterBtn:SetFrameStrata(FRAME_STRATA)
     sourceFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -2938,8 +2987,8 @@ function Viewer:CreateWindow()
     
     
     local qualityFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    qualityFilterBtn:SetSize(70, BUTTON_HEIGHT)
-    qualityFilterBtn:SetPoint("LEFT", sourceFilterBtn, "RIGHT", 5, 0)
+    qualityFilterBtn:SetSize(55, BUTTON_HEIGHT)
+    qualityFilterBtn:SetPoint("LEFT", sourceFilterBtn, "RIGHT", 3, 0)
     qualityFilterBtn:SetText("Quality")
     qualityFilterBtn:SetFrameStrata(FRAME_STRATA)
     qualityFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -2951,8 +3000,8 @@ function Viewer:CreateWindow()
     
     
     local slotsFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    slotsFilterBtn:SetSize(60, BUTTON_HEIGHT)
-    slotsFilterBtn:SetPoint("LEFT", qualityFilterBtn, "RIGHT", 5, 0)
+    slotsFilterBtn:SetSize(42, BUTTON_HEIGHT)
+    slotsFilterBtn:SetPoint("LEFT", qualityFilterBtn, "RIGHT", 3, 0)
     slotsFilterBtn:SetText("Slots")
     slotsFilterBtn:SetFrameStrata(FRAME_STRATA)
     slotsFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -2964,8 +3013,8 @@ function Viewer:CreateWindow()
     
     
     local usableByFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    usableByFilterBtn:SetSize(80, BUTTON_HEIGHT)
-    usableByFilterBtn:SetPoint("LEFT", slotsFilterBtn, "RIGHT", 5, 0)
+    usableByFilterBtn:SetSize(65, BUTTON_HEIGHT)
+    usableByFilterBtn:SetPoint("LEFT", slotsFilterBtn, "RIGHT", 3, 0)
     usableByFilterBtn:SetText("Usable By")
     usableByFilterBtn:SetFrameStrata(FRAME_STRATA)
     usableByFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -2977,8 +3026,8 @@ function Viewer:CreateWindow()
 
     
     local lootedFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    lootedFilterBtn:SetSize(90, BUTTON_HEIGHT)
-    lootedFilterBtn:SetPoint("LEFT", usableByFilterBtn, "RIGHT", 5, 0)
+    lootedFilterBtn:SetSize(75, BUTTON_HEIGHT)
+    lootedFilterBtn:SetPoint("LEFT", usableByFilterBtn, "RIGHT", 3, 0)
     lootedFilterBtn:SetText("Looted: All")
     lootedFilterBtn:SetFrameStrata(FRAME_STRATA)
     lootedFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -3000,10 +3049,33 @@ function Viewer:CreateWindow()
     end)
     lootedFilterBtn:RegisterForClicks("LeftButtonUp")
 
+    -- Collected ME filter button
+    local collectedMEFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
+    collectedMEFilterBtn:SetSize(82, BUTTON_HEIGHT)
+    collectedMEFilterBtn:SetPoint("LEFT", lootedFilterBtn, "RIGHT", 3, 0)
+    collectedMEFilterBtn:SetText("Collected: All")
+    collectedMEFilterBtn:SetFrameStrata(FRAME_STRATA)
+    collectedMEFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
+    collectedMEFilterBtn:SetScript("OnClick", function(self, button)
+        if Viewer.collectedMEFilterState == nil then
+            Viewer.collectedMEFilterState = true
+        elseif Viewer.collectedMEFilterState == true then
+            Viewer.collectedMEFilterState = false
+        else
+            Viewer.collectedMEFilterState = nil
+        end
+        Viewer.currentPage = 1
+        Cache.filteredResults = {}
+        Cache.lastFilterState = nil
+        Viewer:RefreshData()
+        Viewer:UpdateFilterButtonStates()
+    end)
+    collectedMEFilterBtn:RegisterForClicks("LeftButtonUp")
+
     
     local duplicatesFilterBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
-    duplicatesFilterBtn:SetSize(90, BUTTON_HEIGHT)
-    duplicatesFilterBtn:SetPoint("LEFT", lootedFilterBtn, "RIGHT", 5, 0)
+    duplicatesFilterBtn:SetSize(75, BUTTON_HEIGHT)
+    duplicatesFilterBtn:SetPoint("LEFT", collectedMEFilterBtn, "RIGHT", 3, 0)
     duplicatesFilterBtn:SetText("Duplicates")
     duplicatesFilterBtn:SetFrameStrata(FRAME_STRATA)
     duplicatesFilterBtn:SetFrameLevel(FRAME_LEVEL + 1)
@@ -3023,6 +3095,7 @@ function Viewer:CreateWindow()
     self.slotsFilterBtn = slotsFilterBtn
     self.usableByFilterBtn = usableByFilterBtn
     self.lootedFilterBtn = lootedFilterBtn
+    self.collectedMEFilterBtn = collectedMEFilterBtn
     self.duplicatesFilterBtn = duplicatesFilterBtn
 
     
@@ -3264,6 +3337,7 @@ function Viewer:CreateWindow()
         Viewer.columnFilters.duplicates = false 
         
         Viewer.lootedFilterState = nil 
+        Viewer.collectedMEFilterState = nil 
 
         
         Viewer.searchTerm = ""

--- a/PATCH_NOTES_FOR_DEV.md
+++ b/PATCH_NOTES_FOR_DEV.md
@@ -1,0 +1,357 @@
+# Community Patch: "Hide Collected Mystic Enchants" + "Disable Fade Effect"
+
+> **For the LootCollector developer — this document describes every change made to your addon,  
+> written so you can review, adopt, or reject each piece independently.**  
+> All changes are self-contained, backward-compatible, and follow your existing code patterns.
+
+---
+
+## Summary of Features Added
+
+| Feature | Where it shows | Setting key |
+|---|---|---|
+| Hide Collected Mystic Enchants | Map right-click menu, /lc Settings panel, Viewer filter bar | `db.profile.mapFilters.hideCollectedME` |
+| Disable Fade Effect | Map right-click menu, /lc Settings panel | `db.profile.mapFilters.disableFadeEffect` |
+
+---
+
+## Feature 1: Hide Collected Mystic Enchants
+
+### How it works
+
+When the filter is active, any `MYSTIC_SCROLL` discovery whose item has been collected by the 
+current account is hidden. Collection status is detected via tooltip scanning:
+
+1. A hidden `GameTooltip` (named `LootCollectorMEScannerTooltip`) scans the item by `SetHyperlink`.
+2. Each tooltip line's text is stripped of WoW color codes (`|cXXXXXXXX`/`|r`).
+3. If any stripped line equals exactly `"Collected"`, the item is considered collected.
+4. Results are cached for **5 minutes** per `itemID` to avoid repeated tooltip scanning.
+
+> **Note:** `C_MysticEnchant.IsCollected()` was tested but does not exist on Ascension.  
+> The tooltip method works — the "Collected" text from the game client IS accessible via hidden  
+> scanner tooltips (it appears as `|cff1EFF00Collected` — green color code prepended).
+
+---
+
+### File 1 of 4: `LootCollector.lua`
+
+**Change 1 — Default value in `dbDefaults`**
+
+In the `mapFilters` block inside `dbDefaults`, one new key was added:
+
+```lua
+-- ADDED: after hideLearnedTransmog = false,
+hideCollectedME = false,
+```
+
+**Change 2 — Default guard in `GetFilters()`**
+
+One new line was added at the end of `GetFilters()`, before `return f`:
+
+```lua
+-- ADDED: after existing if-nil guards
+if f.disableFadeEffect == nil then f.disableFadeEffect = false end
+```
+
+Wait — see Feature 2 below. `disableFadeEffect` guard is also here.
+
+For `hideCollectedME` specifically, this line was added:
+
+```lua
+if f.hideCollectedME == nil then f.hideCollectedME = false end
+```
+
+**Change 3 — New detection function `IsMysticEnchantCollected()`**
+
+Added a new function after `IsAppearanceCollected()`:
+
+```lua
+local meCollectedCache = {}
+local meCollectedCacheTime = {}
+local ME_COLLECTED_CACHE_DURATION = 300
+
+function LootCollector:IsMysticEnchantCollected(itemID)
+    if not itemID or itemID == 0 then return false end
+
+    local now = GetTime()
+    if meCollectedCacheTime[itemID] and (now - meCollectedCacheTime[itemID]) < ME_COLLECTED_CACHE_DURATION then
+        return meCollectedCache[itemID]
+    end
+
+    local isCollected = false
+
+    -- Try direct API first (Ascension-specific)
+    if C_MysticEnchant and C_MysticEnchant.IsCollected then
+        local ok, result = pcall(C_MysticEnchant.IsCollected, itemID)
+        if ok and result then
+            isCollected = true
+        end
+    end
+
+    -- Fallback: scan the item tooltip for "Collected" text
+    if not isCollected then
+        local scannerName = "LootCollectorMEScannerTooltip"
+        local scanner = _G[scannerName]
+        if not scanner then
+            scanner = CreateFrame("GameTooltip", scannerName, UIParent, "GameTooltipTemplate")
+            scanner:SetOwner(UIParent, "ANCHOR_NONE")
+        end
+        scanner:ClearLines()
+        scanner:SetOwner(UIParent, "ANCHOR_NONE")
+        scanner:SetHyperlink("item:" .. itemID)
+
+        for i = 1, scanner:NumLines() do
+            local leftText = _G[scannerName .. "TextLeft" .. i]
+            if leftText then
+                local text = leftText:GetText()
+                local stripped = text and text:gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "") or ""
+                if stripped == "Collected" then
+                    isCollected = true
+                    break
+                end
+            end
+        end
+        scanner:Hide()
+    end
+
+    meCollectedCache[itemID] = isCollected
+    meCollectedCacheTime[itemID] = now
+
+    return isCollected
+end
+```
+
+**Change 4 — Filter check in `DiscoveryPassesFilters()`**
+
+One new `if` block was added after the `hideLearnedTransmog` check:
+
+```lua
+-- ADDED: after the hideLearnedTransmog block
+if f.hideCollectedME and Constants and d.dt == Constants.DISCOVERY_TYPE.MYSTIC_SCROLL and d.i and d.i > 0 and self:IsMysticEnchantCollected(d.i) then
+    return false
+end
+```
+
+---
+
+### File 2 of 4: `Modules/Map.lua`
+
+**Change 1 — Right-click dropdown menu**
+
+In the `BuildHideSubmenu()` (or equivalent) function that builds the "Hide" submenu, one line was
+added after the "Hide Collected Appearances" toggle:
+
+```lua
+-- ADDED: after addToggle("Hide Collected Appearances", "hideLearnedTransmog", hideSub)
+addToggle("Hide Collected Mystic Enchants", "hideCollectedME", hideSub)
+```
+
+**Change 2 — `AlphaForStatus()` function** *(Feature 2 — see below)*
+
+---
+
+### File 3 of 4: `Modules/Settings.lua`
+
+**Change — New AceConfig toggle in the Visibility section**
+
+After the `hideCollectedME` entry (order 4.2), a new entry was inserted:
+
+```lua
+hideCollectedME = {
+    type = "toggle",
+    name = "Hide Collected Mystic Enchants",
+    order = 4.2,
+    desc = "Hide Mystic Scroll discoveries for enchants you have already collected.",
+    get = function() return L.db.profile.mapFilters.hideCollectedME end,
+    set = function(_, v)
+        L.db.profile.mapFilters.hideCollectedME = v
+        refreshUI()
+    end,
+},
+```
+
+---
+
+### File 4 of 4: `Modules/Viewer.lua`
+
+The Viewer received several additions to integrate a tri-state "Collected" filter button into the 
+filter bar (matching the existing "Looted" tri-state pattern):
+
+**State field** (top of file, near `lootedFilterState`):
+```lua
+Viewer.collectedMEFilterState = nil   -- nil = All, true = Only Collected, false = Only Not Collected
+```
+
+**Filter predicate** — added to both filter paths (the `GetFilteredDatasetForUniqueValues` path
+and the main display path), checking:
+```lua
+if Viewer.collectedMEFilterState ~= nil then
+    local Constants = L:GetModule("Constants", true)
+    if data.isMystic and Constants then
+        local itemID = data.discovery and data.discovery.i
+        local isCollected = itemID and itemID > 0 and L:IsMysticEnchantCollected(itemID)
+        if Viewer.collectedMEFilterState ~= (isCollected == true) then return false end
+    else
+        if Viewer.collectedMEFilterState == true then return false end
+    end
+end
+```
+
+**`HasActiveFilters()`** — added one new condition:
+```lua
+or Viewer.collectedMEFilterState ~= nil
+```
+
+**`UpdateFilterButtonStates()`** — added handler for the new button:
+```lua
+if Viewer.collectedMEBtn then
+    if Viewer.collectedMEFilterState == nil then
+        Viewer.collectedMEBtn:SetText("Collected: All")
+        Viewer.collectedMEBtn:SetNormalFontObject("GameFontNormal")
+    elseif Viewer.collectedMEFilterState == false then
+        Viewer.collectedMEBtn:SetText("Collected: No")
+        Viewer.collectedMEBtn:SetNormalFontObject("GameFontHighlight")
+    else
+        Viewer.collectedMEBtn:SetText("Collected: Yes")
+        Viewer.collectedMEBtn:SetNormalFontObject("GameFontHighlight")
+    end
+end
+```
+
+**Clear All** — reset added alongside `lootedFilterState`:
+```lua
+Viewer.collectedMEFilterState = nil
+```
+
+**Filter state hash** — added to the string that determines if a re-filter is needed:
+```lua
+.. tostring(Viewer.collectedMEFilterState)
+```
+
+**Button creation** — a new button was created following the exact same pattern as the Looted button:
+```lua
+local collectedMEBtn = CreateFrame("Button", nil, additionalFiltersFrame, "UIPanelButtonTemplate")
+collectedMEBtn:SetSize(87, 22)  -- adjusted to fit within the original 556px frame
+collectedMEBtn:SetPoint("LEFT", lootedBtn, "RIGHT", 3, 0)
+collectedMEBtn:SetText("Collected: All")
+collectedMEBtn:SetScript("OnClick", function()
+    if Viewer.collectedMEFilterState == nil then
+        Viewer.collectedMEFilterState = false
+    elseif Viewer.collectedMEFilterState == false then
+        Viewer.collectedMEFilterState = true
+    else
+        Viewer.collectedMEFilterState = nil
+    end
+    Viewer:RequestRefresh()
+    Viewer:UpdateFilterButtonStates()
+end)
+collectedMEBtn:SetScript("OnEnter", function(self)
+    GameTooltip:SetOwner(self, "ANCHOR_TOP")
+    GameTooltip:SetText("Collected ME Filter", 1, 1, 1)
+    GameTooltip:AddLine("All: show all Mystic Scroll discoveries", 0.8, 0.8, 0.8)
+    GameTooltip:AddLine("No: show only uncollected Mystic Scrolls", 0.8, 0.8, 0.8)
+    GameTooltip:AddLine("Yes: show only already-collected Mystic Scrolls", 0.8, 0.8, 0.8)
+    GameTooltip:Show()
+end)
+collectedMEBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+Viewer.collectedMEBtn = collectedMEBtn
+```
+
+**Layout adjustment** — To fit the new button, other buttons in the 556px filter bar were 
+slightly reduced and gaps changed from 5px to 3px between buttons:
+```
+Source: 65px, Quality: 65px, Slots: 55px, Usable By: 75px, Looted: 82px, Collected: 87px, Duplicates: 78px
+```
+
+---
+
+## Feature 2: Disable Fade Effect
+
+### How it works
+
+When enabled, the `AlphaForStatus()` function in Map.lua immediately returns `1.0` (full opacity)
+for all pin statuses, bypassing the FADING (65%) and STALE (45%) alpha reductions.
+
+---
+
+### `LootCollector.lua` changes
+
+**`dbDefaults`** — new key:
+```lua
+-- ADDED: after hidePlayerNames
+disableFadeEffect = false,
+```
+
+**`GetFilters()`** — new guard:
+```lua
+-- ADDED: before return f
+if f.disableFadeEffect == nil then f.disableFadeEffect = false end
+```
+
+---
+
+### `Modules/Map.lua` changes
+
+**`AlphaForStatus()`** — the function was modified:
+
+```lua
+-- BEFORE:
+local function AlphaForStatus(status)
+  if status == "FADING" then return 0.65 elseif status == "STALE" then return 0.45 end
+  return 1.0
+end
+
+-- AFTER:
+local function AlphaForStatus(status)
+  local f = L:GetFilters()
+  if f.disableFadeEffect then return 1.0 end
+  if status == "FADING" then return 0.65 elseif status == "STALE" then return 0.45 end
+  return 1.0
+end
+```
+
+**Right-click dropdown menu** — one separator and toggle added after the `hideCollectedME` toggle:
+```lua
+-- ADDED: after addToggle("Hide Collected Mystic Enchants", ...)
+table.insert(hideSub, { text = "", notCheckable = true, disabled = true })
+addToggle("Disable Fade Effect", "disableFadeEffect", hideSub)
+```
+
+---
+
+### `Modules/Settings.lua` changes
+
+**New AceConfig toggle** — inserted after `hideCollectedME` (order 4.2), at order 4.3:
+```lua
+disableFadeEffect = {
+    type = "toggle",
+    name = "Disable Fade Effect",
+    order = 4.3,
+    desc = "Show all map pins at full opacity, even if their discovery is fading or stale.",
+    get = function() return L.db.profile.mapFilters.disableFadeEffect end,
+    set = function(_, v)
+        L.db.profile.mapFilters.disableFadeEffect = v
+        refreshUI()
+    end,
+},
+```
+
+---
+
+## Diagnostic Command (can be removed)
+
+A `/lcme <itemID>` slash command was added to `LootCollector.lua` for debugging purposes.  
+It dumps `C_MysticEnchant` API methods and tests collection detection for a given item ID.  
+**This can be safely removed** — it was only used to discover the correct detection approach  
+and is not part of the permanent feature.
+
+---
+
+## Compatibility Notes
+
+- **SavedVariables**: New keys (`hideCollectedME`, `disableFadeEffect`) default to `false` and  
+  are guarded in `GetFilters()`, so existing saves are unaffected.
+- **No new global functions** are exposed — all new functions are addon-scoped (`LootCollector:`).
+- **No taint risk** — tooltip scanner uses `UIParent` as owner, not any Blizzard secure frame.
+- **No breaking changes** — all existing behavior is preserved when the new toggles are off  
+  (which is the default).


### PR DESCRIPTION
Made some small changes to v0.7.48 with AI:
- a filter to hide  your Collected Mystic Enchants
- a filter to hide WF items you've collected their appearance
- small option to disable the fading effect of the stale items
This made my life much easier to collect MEs for all my alts at once.

Full technical details are in PATCH_NOTES_FOR_DEV.md (included in this PR).