### PR TITLE
Feat/search in tooltips

### DIFF
--- a/LootCollector.lua
+++ b/LootCollector.lua
@@ -468,7 +468,57 @@ function LootCollector:IsLootedByChar(guid)
     return self.db.char.looted[guid] and true or false
 end
 
+-- Returns true if this character has already looted any discovery with the given
+-- itemID in the given zone. Used to suppress incoming network duplicates.
+function LootCollector:IsSameZoneAlreadyLootedByChar(itemID, zoneID)
+    if not itemID or not zoneID then return false end
+    if not (self.db and self.db.char and self.db.char.looted) then return false end
+    local discoveries = self:GetDiscoveriesDB()
+    if not discoveries then return false end
+    for guid, _ in pairs(self.db.char.looted) do
+        local d = discoveries[guid]
+        if d and d.i == itemID and d.z == zoneID then
+            return true
+        end
+    end
+    return false
+end
 
+-- When a discovery is looted, immediately remove same-zone duplicates (same itemID + same
+-- zone) from the discoveries DB. Duplicates in different zones are left untouched.
+-- Returns the number of duplicate entries removed.
+function LootCollector:MarkSameZoneDuplicatesLooted(lootedGuid)
+    if not lootedGuid then return 0 end
+    local discoveries = self:GetDiscoveriesDB()
+    if not discoveries then return 0 end
+
+    local src = discoveries[lootedGuid]
+    if not src or not src.i or not src.z then return 0 end
+
+    local itemID = src.i
+    local zoneID = src.z
+
+    -- Collect duplicate GUIDs first (never mutate a table while pairs() iterates it).
+    local toRemove = {}
+    for guid, d in pairs(discoveries) do
+        if guid ~= lootedGuid and d and d.i == itemID and d.z == zoneID then
+            toRemove[#toRemove + 1] = guid
+        end
+    end
+
+    -- Delete each duplicate and fire the standard removal event so the map pins
+    -- and Viewer cache react immediately, without needing a /reload.
+    for _, guid in ipairs(toRemove) do
+        discoveries[guid] = nil
+        self:SendMessage("LootCollector_DiscoveriesUpdated", "remove", guid, nil)
+    end
+
+    if #toRemove > 0 then
+        self.DataHasChanged = true
+    end
+
+    return #toRemove
+end
 
 local appearanceCache = {}
 local appearanceCacheTime = {}

--- a/Modules/Core.lua
+++ b/Modules/Core.lua
@@ -2326,6 +2326,9 @@ function Core:HandleLocalLoot(discovery)
      if L.db and L.db.char then
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[rec.g] = time()
+        -- Remove same-zone duplicates of this item immediately (same as startup deduplication,
+        -- but triggered at loot-time so pins disappear without a /reload).
+        L:MarkSameZoneDuplicatesLooted(rec.g)
     end
     
     
@@ -2984,6 +2987,12 @@ function Core:AddDiscovery(discoveryData, options)
             fp_votes = { [finderName] = { score = 1, t0 = t0 } },
             s_flag = s_flag,
         }
+
+        -- If this character already looted this item in this zone, don't add the incoming
+        -- duplicate — it would reappear on the map even though the item can't be looted again.
+        if L:IsSameZoneAlreadyLootedByChar(itemID, z) then
+            return
+        end
 
         db[guid] = rec
         self:AddToZoneIndex(guid, z)

--- a/Modules/Map.lua
+++ b/Modules/Map.lua
@@ -1285,6 +1285,8 @@ function Map:OpenPinMenu(anchorFrame)
         if not (L.db and L.db.char) then return end
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[d.g] = time()
+        -- Also mark same-zone duplicates as looted.
+        L:MarkSameZoneDuplicatesLooted(d.g)
         Map.cacheIsDirty = true 
         Map:Update()
       end })

--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -9,6 +9,28 @@ function ViewerSetSelectedRow(row)
     end
 end
 
+local tooltipScanner = CreateFrame("GameTooltip", "LCSearchTooltipScanner", nil, "GameTooltipTemplate")
+tooltipScanner:SetOwner(UIParent, "ANCHOR_NONE")
+
+local function GetItemTooltipText(itemLink)
+    if not itemLink or itemLink == "" then return nil end
+    tooltipScanner:ClearLines()
+    tooltipScanner:SetHyperlink(itemLink)
+    local fullText = ""
+    for i = 1, tooltipScanner:NumLines() do
+        local left = _G["LCSearchTooltipScannerTextLeft"..i]
+        if left and left:GetText() then
+            fullText = fullText .. " " .. left:GetText()
+        end
+        local right = _G["LCSearchTooltipScannerTextRight"..i]
+        if right and right:GetText() then
+            fullText = fullText .. " " .. right:GetText()
+        end
+    end
+    if fullText == "" then return nil end
+    return string.lower(fullText)
+end
+
 local SOURCE_NAMES = {
     ["world_loot"] = "World Drop",
     ["mail"] = "Mail",
@@ -44,6 +66,7 @@ local CLASS_OPTIONS = {
 
 Viewer.lootedFilterState = nil 
 Viewer.collectedMEFilterState = nil 
+Viewer.searchTooltipsEnabled = false
 
 local time = time or os.time
 
@@ -1651,6 +1674,7 @@ function Viewer:ProcessScanQueueBatch()
                         minLevel      = minLevel,
                         cl            = discovery.cl,
                         isVendor      = false,
+                        tooltipText   = GetItemTooltipText(itemLink),
                     })
 
                     processedInBatch = processedInBatch + 1
@@ -1795,6 +1819,7 @@ function Viewer:UpdateAllDiscoveriesCacheSync()
                         minLevel      = minLevel,
                         cl            = discovery.cl,
                         isVendor      = false, 
+                        tooltipText   = GetItemTooltipText(itemLink),
                     })
 
                     processedItems = processedItems + 1
@@ -1896,7 +1921,12 @@ function Viewer:GetFilteredDiscoveries()
             local zoneName  = GetLocalizedZoneName(data.discovery)
             local zoneMatch = _strfind(_strlower(zoneName), searchLower, 1, true)
 
-            return nameMatch or zoneMatch
+            local tooltipMatch = false
+            if Viewer.searchTooltipsEnabled and data.tooltipText then
+                tooltipMatch = _strfind(data.tooltipText, searchLower, 1, true)
+            end
+
+            return nameMatch or zoneMatch or tooltipMatch
         end,
 
         
@@ -2640,6 +2670,21 @@ function Viewer:CreateWindow()
         clearBtn:Hide()
     end)
     clearBtn:Hide() 
+
+    local tooltipCheck = CreateFrame("CheckButton", "LCSearchTooltipCheck", window, "UICheckButtonTemplate")
+    tooltipCheck:SetSize(24, 24)
+    tooltipCheck:SetPoint("LEFT", searchBox, "RIGHT", 30, 0)
+    tooltipCheck:SetChecked(Viewer.searchTooltipsEnabled)
+    
+    local tooltipLabel = tooltipCheck:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    tooltipLabel:SetPoint("LEFT", tooltipCheck, "RIGHT", 0, 0)
+    tooltipLabel:SetText("Search Tooltips")
+
+    tooltipCheck:SetScript("OnClick", function(self)
+        Viewer.searchTooltipsEnabled = self:GetChecked()
+        Viewer.currentPage = 1
+        Viewer:RefreshData()
+    end)
         
 
     local autocompleteDropdown = nil

--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -4483,6 +4483,11 @@ function Viewer:ToggleLootedState(guid, discoveryData)
         
         L.db.char.looted[guid] = time()
         print(string.format("|cff00ff00LootCollector:|r Marked '%s' as looted.", discoveryData.itemName or "Unknown Item"))
+        -- Also mark same-zone duplicates of this item as looted locally.
+        local extraMarked = L:MarkSameZoneDuplicatesLooted(guid)
+        if extraMarked > 0 then
+            print(string.format("|cff00ff00LootCollector:|r Also marked %d same-zone duplicate(s) as looted.", extraMarked))
+        end
     end
 
     


### PR DESCRIPTION
How it Works:
- **Tooltip Scanner**: We created a hidden, dedicated GameTooltip scanner frame (LCSearchTooltipScanner) that avoids interfering with the player's UI.
- **Data Extraction**: When items are queued in the caching/processing batches (ProcessScanQueueBatch and UpdateAllDiscoveriesCacheSync), the add-on passes the itemLink to a new GetItemTooltipText() function. This function populates the hidden tooltip and iterates over all left and right lines (LCSearchTooltipScannerTextLeft/Right), concatenating the strings into a single lowercase searchable tooltipText property.
- **UI Integration & Filtering:** A checkbox was added to the Viewer window ("Search Tooltips"). When ticked, Viewer:GetFilteredDiscoveries() extends its normal _strfind matching behavior to also evaluate the cached tooltipText property against the user's search query. This lets players search for very specific set bonuses, flavor texts, or spell effects directly from the viewer.