### PR TITLE
Feat/optimized deduplication

### DIFF
--- a/LootCollector.lua
+++ b/LootCollector.lua
@@ -468,7 +468,57 @@ function LootCollector:IsLootedByChar(guid)
     return self.db.char.looted[guid] and true or false
 end
 
+-- Returns true if this character has already looted any discovery with the given
+-- itemID in the given zone. Used to suppress incoming network duplicates.
+function LootCollector:IsSameZoneAlreadyLootedByChar(itemID, zoneID)
+    if not itemID or not zoneID then return false end
+    if not (self.db and self.db.char and self.db.char.looted) then return false end
+    local discoveries = self:GetDiscoveriesDB()
+    if not discoveries then return false end
+    for guid, _ in pairs(self.db.char.looted) do
+        local d = discoveries[guid]
+        if d and d.i == itemID and d.z == zoneID then
+            return true
+        end
+    end
+    return false
+end
 
+-- When a discovery is looted, immediately remove same-zone duplicates (same itemID + same
+-- zone) from the discoveries DB. Duplicates in different zones are left untouched.
+-- Returns the number of duplicate entries removed.
+function LootCollector:MarkSameZoneDuplicatesLooted(lootedGuid)
+    if not lootedGuid then return 0 end
+    local discoveries = self:GetDiscoveriesDB()
+    if not discoveries then return 0 end
+
+    local src = discoveries[lootedGuid]
+    if not src or not src.i or not src.z then return 0 end
+
+    local itemID = src.i
+    local zoneID = src.z
+
+    -- Collect duplicate GUIDs first (never mutate a table while pairs() iterates it).
+    local toRemove = {}
+    for guid, d in pairs(discoveries) do
+        if guid ~= lootedGuid and d and d.i == itemID and d.z == zoneID then
+            toRemove[#toRemove + 1] = guid
+        end
+    end
+
+    -- Delete each duplicate and fire the standard removal event so the map pins
+    -- and Viewer cache react immediately, without needing a /reload.
+    for _, guid in ipairs(toRemove) do
+        discoveries[guid] = nil
+        self:SendMessage("LootCollector_DiscoveriesUpdated", "remove", guid, nil)
+    end
+
+    if #toRemove > 0 then
+        self.DataHasChanged = true
+    end
+
+    return #toRemove
+end
 
 local appearanceCache = {}
 local appearanceCacheTime = {}

--- a/LootCollector.lua
+++ b/LootCollector.lua
@@ -472,16 +472,24 @@ end
 -- itemID in the given zone. Used to suppress incoming network duplicates.
 function LootCollector:IsSameZoneAlreadyLootedByChar(itemID, zoneID)
     if not itemID or not zoneID then return false end
-    if not (self.db and self.db.char and self.db.char.looted) then return false end
-    local discoveries = self:GetDiscoveriesDB()
-    if not discoveries then return false end
-    for guid, _ in pairs(self.db.char.looted) do
-        local d = discoveries[guid]
-        if d and d.i == itemID and d.z == zoneID then
-            return true
+    if not (self.db and self.db.char) then return false end
+
+    if not self.db.char.lootedByZone then
+        self.db.char.lootedByZone = {}
+        if self.db.char.looted then
+            local discoveries = self:GetDiscoveriesDB()
+            if discoveries then
+                for guid, _ in pairs(self.db.char.looted) do
+                    local d = discoveries[guid]
+                    if d and d.i and d.z then
+                        self.db.char.lootedByZone[d.i .. ":" .. d.z] = true
+                    end
+                end
+            end
         end
     end
-    return false
+
+    return self.db.char.lootedByZone[itemID .. ":" .. zoneID] or false
 end
 
 -- When a discovery is looted, immediately remove same-zone duplicates (same itemID + same

--- a/Modules/Core.lua
+++ b/Modules/Core.lua
@@ -2326,6 +2326,10 @@ function Core:HandleLocalLoot(discovery)
      if L.db and L.db.char then
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[rec.g] = time()
+        if rec.i and rec.z then
+            L.db.char.lootedByZone = L.db.char.lootedByZone or {}
+            L.db.char.lootedByZone[rec.i .. ":" .. rec.z] = true
+        end
         -- Remove same-zone duplicates of this item immediately (same as startup deduplication,
         -- but triggered at loot-time so pins disappear without a /reload).
         L:MarkSameZoneDuplicatesLooted(rec.g)

--- a/Modules/Core.lua
+++ b/Modules/Core.lua
@@ -2326,6 +2326,9 @@ function Core:HandleLocalLoot(discovery)
      if L.db and L.db.char then
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[rec.g] = time()
+        -- Remove same-zone duplicates of this item immediately (same as startup deduplication,
+        -- but triggered at loot-time so pins disappear without a /reload).
+        L:MarkSameZoneDuplicatesLooted(rec.g)
     end
     
     
@@ -2984,6 +2987,12 @@ function Core:AddDiscovery(discoveryData, options)
             fp_votes = { [finderName] = { score = 1, t0 = t0 } },
             s_flag = s_flag,
         }
+
+        -- If this character already looted this item in this zone, don't add the incoming
+        -- duplicate — it would reappear on the map even though the item can't be looted again.
+        if L:IsSameZoneAlreadyLootedByChar(itemID, z) then
+            return
+        end
 
         db[guid] = rec
         self:AddToZoneIndex(guid, z)

--- a/Modules/Map.lua
+++ b/Modules/Map.lua
@@ -1285,6 +1285,10 @@ function Map:OpenPinMenu(anchorFrame)
         if not (L.db and L.db.char) then return end
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[d.g] = time()
+        if d.i and d.z then
+            L.db.char.lootedByZone = L.db.char.lootedByZone or {}
+            L.db.char.lootedByZone[d.i .. ":" .. d.z] = true
+        end
         -- Also mark same-zone duplicates as looted.
         L:MarkSameZoneDuplicatesLooted(d.g)
         Map.cacheIsDirty = true 
@@ -1293,6 +1297,10 @@ function Map:OpenPinMenu(anchorFrame)
       table.insert(menuList, { text = "Set as unlooted", notCheckable = true, func = function()
         if not (L.db and L.db.char and L.db.char.looted) then return end
         L.db.char.looted[d.g] = nil
+        if d.i and d.z then
+            L.db.char.lootedByZone = L.db.char.lootedByZone or {}
+            L.db.char.lootedByZone[d.i .. ":" .. d.z] = nil
+        end
         Map.cacheIsDirty = true 
         Map:Update()
       end })

--- a/Modules/Map.lua
+++ b/Modules/Map.lua
@@ -1285,6 +1285,8 @@ function Map:OpenPinMenu(anchorFrame)
         if not (L.db and L.db.char) then return end
         L.db.char.looted = L.db.char.looted or {}
         L.db.char.looted[d.g] = time()
+        -- Also mark same-zone duplicates as looted.
+        L:MarkSameZoneDuplicatesLooted(d.g)
         Map.cacheIsDirty = true 
         Map:Update()
       end })

--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -4477,11 +4477,25 @@ function Viewer:ToggleLootedState(guid, discoveryData)
     if isCurrentlyLooted then
         
         L.db.char.looted[guid] = nil
+        if discoveryData and discoveryData.discovery then
+            local d = discoveryData.discovery
+            if d.i and d.z then
+                L.db.char.lootedByZone = L.db.char.lootedByZone or {}
+                L.db.char.lootedByZone[d.i .. ":" .. d.z] = nil
+            end
+        end
         print(string.format("|cff00ff00LootCollector:|r Marked '%s' as unlooted.",
             discoveryData.itemName or "Unknown Item"))
     else
         
         L.db.char.looted[guid] = time()
+        if discoveryData and discoveryData.discovery then
+            local d = discoveryData.discovery
+            if d.i and d.z then
+                L.db.char.lootedByZone = L.db.char.lootedByZone or {}
+                L.db.char.lootedByZone[d.i .. ":" .. d.z] = true
+            end
+        end
         print(string.format("|cff00ff00LootCollector:|r Marked '%s' as looted.", discoveryData.itemName or "Unknown Item"))
         -- Also mark same-zone duplicates of this item as looted locally.
         local extraMarked = L:MarkSameZoneDuplicatesLooted(guid)

--- a/Modules/Viewer.lua
+++ b/Modules/Viewer.lua
@@ -4483,6 +4483,11 @@ function Viewer:ToggleLootedState(guid, discoveryData)
         
         L.db.char.looted[guid] = time()
         print(string.format("|cff00ff00LootCollector:|r Marked '%s' as looted.", discoveryData.itemName or "Unknown Item"))
+        -- Also mark same-zone duplicates of this item as looted locally.
+        local extraMarked = L:MarkSameZoneDuplicatesLooted(guid)
+        if extraMarked > 0 then
+            print(string.format("|cff00ff00LootCollector:|r Also marked %d same-zone duplicate(s) as looted.", extraMarked))
+        end
     end
 
     


### PR DESCRIPTION
**The Problem:** The previous deduplication logic was highly inefficient. Inside LootCollector:IsSameZoneAlreadyLootedByChar, the add-on was running a linear $O(N)$ loop (for guid, _ in pairs(self.db.char.looted)) to cross-reference every looted item's ID and Zone ID. As a player's looted database grew, this caused CPU overhead and traffic lag whenever duplicates were checked or items were looted.

**O(1) Lookup Cache:** We introduced a specialized caching table called self.db.char.lootedByZone. This table keys off of a simple string concatenation: [itemID .. ":" .. zoneID] = true.

**Initialization:** The first time IsSameZoneAlreadyLootedByChar is called, if lootedByZone doesn't exist, it builds it exactly once by iterating through self.db.char.looted.

**Real-time Updates:** To keep the cache synchronized without ever having to rebuild it, we injected update hooks directly into Core:HandleLocalLoot(), Map:OpenPinMenu(), and Viewer:ToggleLootedState(). Whenever a user loots, unloots, or manually toggles a discovery, the lootedByZone dictionary is instantly patched.

**The Result:** Future duplicate checks return instantly (return self.db.char.lootedByZone[itemID .. ":" .. zoneID]), severely reducing the footprint required for network duplicate suppression.